### PR TITLE
fixed the messagebox container gaining a scrollbar

### DIFF
--- a/src/static/room.css
+++ b/src/static/room.css
@@ -740,7 +740,7 @@ body {
 .message-box {
   position: relative;
   padding-left: 3.5em;
-  overflow: auto;
+  overflow: hidden;
 }
 .message-box.notimes {
   padding-left: 0;


### PR DESCRIPTION
Fixed the issue on chrome for android and chromium based browsers on GNU/linux and windows. There was no need for the container to be overflow: auto; as its a flexbox and it resizes itself instead of overflowing when new messages are added to it.